### PR TITLE
fix #22: inform users that data in file is invalid

### DIFF
--- a/inst/sampleDB/server_helpers/AppMoveMicronixSamples.R
+++ b/inst/sampleDB/server_helpers/AppMoveMicronixSamples.R
@@ -54,27 +54,17 @@ MoveWetlabSamples <- function(session, input, database, output){
   observeEvent(
     input$MoveAction,
     ({
-      
-      # set move reqs (reqs are enforced ui checks)
-      SetMoveRequirements(input, sample_type = "micronix")
-      # fire move trigger
-      updateTextInput(session = session, "ActionMoveMatrix", value = "Go"); Sys.sleep(.75)
-      # print "Working..." user message
-      output$MoveReturnMessage1 <- renderText({"Working..."})
-    }))
-  
-  # move samples - the pkg move fun contains enforced checks
-  observe({
-    if(input$ActionMoveMatrix == "Go"){
-      return_message <- sampleDB::MoveSamples(sample_type = input$MoveSampleType,
-                            move_data = reactive_vals$formatted_move_file_list)
-      
-      # print user message
-      output$MoveReturnMessage2 <- renderText({return_message})
-      # reset trigger
-      updateTextInput(session = session, "ActionMoveMatrix", value = "")
-    }
-  })
+      output$MoveReturnMessage2 <- renderText({
+
+        # set move reqs (reqs are enforced ui checks)
+        SetMoveRequirements(input, sample_type = "micronix")
+
+        sampleDB::MoveSamples(sample_type = input$MoveSampleType,
+                              move_data = reactive_vals$formatted_move_file_list)
+        
+      })
+    })
+  )
   
   # allow user to reset ui
   MoveReset(input, output)

--- a/inst/sampleDB/ui_helpers/UIMicronixUpload.R
+++ b/inst/sampleDB/ui_helpers/UIMicronixUpload.R
@@ -20,6 +20,7 @@ UIMicronixUpload <- function(){
       textOutput("WarningMicronixUploadMetadataColnames"),
       textOutput("WarningUploadMicronixSpecimenTypes"),
       textOutput("WarningMicronixUploadDateFormat"),
+      textOutput("WarningUploadInvalidData"),
       textOutput("WarningUploadMicronixStudyShortCodes"),
       textOutput("WarningMicronixSpecimenExists"),
       #insert plate infor

--- a/inst/sampleDB/ui_helpers/UIMoveSamples.R
+++ b/inst/sampleDB/ui_helpers/UIMoveSamples.R
@@ -24,7 +24,6 @@ UIMoveSamples <- function(){
       textOutput("WarningMoveBarcodesExist"),
       actionButton("CreateEmptyMicronixPlate", "Create Empty Micronix Plate"),
       verbatimTextOutput("CreateEmptyMicronixPlateMessage"),
-      verbatimTextOutput("MoveReturnMessage1"),
       verbatimTextOutput("MoveReturnMessage2"),
     ),
     mainPanel(


### PR DESCRIPTION
fix #14: swap out stopifnot with validate

fix #14: wrap output text around code to capture validate-needs AND stopifnot messages. this taps into the error handling built into shiny.