### PR TITLE
jdi: search tables are nulled if there are no

### DIFF
--- a/R/ArchiveAndDeleteSamples.R
+++ b/R/ArchiveAndDeleteSamples.R
@@ -35,6 +35,8 @@ ArchiveAndDeleteSamples <- function(operation, data, comment, status, verificati
   conn <-  RSQLite::dbConnect(RSQLite::SQLite(), database)
   RSQLite::dbBegin(conn)
 
+  stopifnot("Status is not valid" = status %in% CheckTable("status")$name)
+
   status_id <- filter(sampleDB::CheckTable("status"), name %in% status)$id
   state_id <- filter(sampleDB::CheckTable("state"), name %in% "Archived")$id
 

--- a/inst/sampleDB/server_helpers/AppDelArchSamples.R
+++ b/inst/sampleDB/server_helpers/AppDelArchSamples.R
@@ -19,7 +19,9 @@ DelArchSamples <- function(session, input, database, output, inputs, outputs){
       storage_container_ids <- list.search_results$id.wetlab_samples 
       values$data <- search_results %>%
         mutate(`Sample ID` = storage_container_ids)    
-      }
+    } else {
+      values$data <- NULL
+    }
   })
 
   # print search results
@@ -46,6 +48,8 @@ DelArchSamples <- function(session, input, database, output, inputs, outputs){
   observeEvent(input[[ui_elements$ui.input$ArchiveAction]], {
     output[[ui_elements$ui.output$DelArchMessage]] <- NULL
     values$operation <- "archive"
+    req(input$DelArchStatus)
+
     showModal(dataModal(operation = values$operation, data = values$selected()))
   })
   

--- a/inst/sampleDB/server_helpers/AppSearchSamples.R
+++ b/inst/sampleDB/server_helpers/AppSearchSamples.R
@@ -15,15 +15,13 @@ SearchWetlabSamples <- function(session, input, database, output, DelArch = FALS
     
     if(!is.null(list.search_results)){
       values$data <- list.search_results$results
-      storage_container_ids <- list.search_results$id.wetlab_samples 
     } else {
       values$data <- NULL
-      storage_container_ids <- NULL
     }
     
     # print search results
     output[[ui_elements$ui.output$SearchResultsTable]] <- DT::renderDataTable({
-      if(!is.null(list.search_results)){
+      if(!is.null(values$data)){
         values$data
       }else{
         tibble(a = c(1)) %>% filter(a == 2)


### PR DESCRIPTION
matching filters now, which makes the table clear out -
behavior that is expected by the user. Also, archiving
requires a status.