### PR TITLE
If the Rack ID or PlateName column exists during moves, override the …

### DIFF
--- a/R/ProcessCSV.R
+++ b/R/ProcessCSV.R
@@ -83,6 +83,8 @@ ProcessCSV <- function(user_csv, user_action, sample_storage_type, search_type =
 
   ## Required Column Names
   required_user_column_names <- conditional_user_column_names <- optional_user_column_names <- NULL
+  manifest_name <- NULL
+
   if (user_action %in% c("move", "upload")) {
 
     file_index <- which(lapply(file_specs_json$file_types, function(x) x$id) == file_type)
@@ -105,7 +107,12 @@ ProcessCSV <- function(user_csv, user_action, sample_storage_type, search_type =
       conditional_user_column_names <- c(conditional_user_column_names, file_specs_json$shared$upload[['conditional']])
       optional_user_column_names <- c(optional_user_column_names, file_specs_json$shared$upload[['optional']])
 
-      manifest_name <- file_specs_json$shared$sample_type[[sample_type_index]]$manifest$name
+      if (file_type == "traxcer") {
+        manifest_name <- "Rack ID"
+      } else {
+        manifest_name <- file_specs_json$shared$sample_type[[sample_type_index]]$manifest$name
+      }
+
       manifest_barcode_name <- file_specs_json$shared$sample_type[[sample_type_index]]$manifest$barcode
       location_parameters <- file_specs_json$shared$sample_type[[sample_type_index]]$location
       location_parameters <- unlist(location_parameters[c("name", "level_I", "level_II")])
@@ -113,7 +120,12 @@ ProcessCSV <- function(user_csv, user_action, sample_storage_type, search_type =
       required_user_column_names <- c(required_user_column_names, c(manifest_name, unname(location_parameters)))
       optional_user_column_names <- c(optional_user_column_names, c(manifest_barcode_name))
     } else if (user_action %in% "move") {
-      manifest_name <- file_specs_json$shared$sample_type[[sample_type_index]]$manifest$name
+      if (file_type == "traxcer") {
+        manifest_name <- "Rack ID"
+      } else {
+        manifest_name <- file_specs_json$shared$sample_type[[sample_type_index]]$manifest$name
+      }
+      required_user_column_names <- c(required_user_column_names, manifest_name)
     }
   } else { ## Search
     if (search_type %in% c("barcode", "study_subject")) {

--- a/inst/sampleDB/server_helpers/AppMoveSamples.R
+++ b/inst/sampleDB/server_helpers/AppMoveSamples.R
@@ -415,6 +415,13 @@ AppMoveSamples <- function(session, input, output, database) {
             container_name = manifest_name
           )
 
+          # Special Case. The file can contain the plate name
+          # and will override what is extracted from the file path.
+          # Reassign manifest name the value that is in the resulting
+          # dataframe because it is guaranteed to have either the value
+          # in the file of the value extracted from the filename.
+          manifest_name <- unique(result$manifest_name)
+
           move_data_list <- c(move_data_list, list(result))
           names(move_data_list)[i] <- manifest_name
         }

--- a/inst/sampleDB/server_helpers/AppUploadSamples.R
+++ b/inst/sampleDB/server_helpers/AppUploadSamples.R
@@ -642,7 +642,11 @@ AppUploadSamples <- function(session, input, output, database, dbUpdateEvent) {
       example_data$conditional <- conditional_user_column_names <- c(conditional_user_column_names, file_specs_json$shared$upload[['conditional']])
       optional_user_column_names <- c(optional_user_column_names, file_specs_json$shared$upload[['optional']])
 
-      manifest_name <- file_specs_json$shared$sample_type[[sample_type_index]]$manifest$name
+      manifest_name <- if (input$UploadFileType == "traxcer") {
+        "Rack ID"
+      } else {
+        file_specs_json$shared$sample_type[[sample_type_index]]$manifest$name
+      }
       manifest_barcode_name <- file_specs_json$shared$sample_type[[sample_type_index]]$manifest$barcode
       location_parameters <- file_specs_json$shared$sample_type[[sample_type_index]]$location
       location_parameters <- unlist(location_parameters[c("name", "level_I", "level_II")])


### PR DESCRIPTION
…filename. If the column does not exist,

continue to use the filename.